### PR TITLE
changes to the help commands [bot name] -> hubot (works when bot is not called hubot)

### DIFF
--- a/src/sentiment.coffee
+++ b/src/sentiment.coffee
@@ -3,12 +3,12 @@
 #   All bot commands can be sent via PM as well.
 #
 # Commands:
-#   [bot name] sentiment - lists sentiment stats
-#   [bot name] how am i? - details about the current channel + you
-#   [bot name] who's happy? - who's happiest?
-#   [bot name] who's stressed? - who's stressed out?
-#   [bot name] where's happiness? - which rooms are happiest?
-#   [bot name] where's stress? - which rooms are stressed out?
+#   hubot sentiment - lists sentiment stats
+#   hubot how am i? - details about the current channel + you
+#   hubot who's happy? - who's happiest?
+#   hubot who's stressed? - who's stressed out?
+#   hubot where's happiness? - which rooms are happiest?
+#   hubot where's stress? - which rooms are stressed out?
 #
 # Author:
 #   Michi Kono


### PR DESCRIPTION
[bot name] how am i? - details about the current channel + you
[bot name] sentiment - lists sentiment stats
[bot name] where's happiness? - which rooms are happiest?
[bot name] where's stress? - which rooms are stressed out?
[bot name] who's happy? - who's happiest?
[bot name] who's stressed? - who's stressed out?
chatbot adapter - Reply with the adapter

we now use hubot so we get a nicer output:
chatbot adapter - Reply with the adapter
chatbot how am i? - details about the current channel + you
chatbot sentiment - lists sentiment stats
chatbot where's happiness? - which rooms are happiest?
chatbot where's stress? - which rooms are stressed out?
chatbot who's happy? - who's happiest?
chatbot who's stressed? - who's stressed out?
